### PR TITLE
Use absolute uris for preview images

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 [![Open in your Home Assistant instance][my-ha-badge]][my-ha-url]
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="
-https://raw.githubusercontent.com/JonasDoebertin/ha-today-card/main/docs/preview-dark.png">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/JonasDoebertin/ha-today-card/main/docs/preview-dark.png">
   <img width="500" height="334" alt="Today Card for Home Assistant Lovelace Preview" src="https://raw.githubusercontent.com/JonasDoebertin/ha-today-card/main/docs/preview-light.png">
 </picture>
 


### PR DESCRIPTION
This should allow the preview images to be viewed in the HACS repository view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated image URLs in the README to use absolute GitHub links for improved image display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->