### PR TITLE
Fix a layout bug for cards without a title

### DIFF
--- a/src/elements/card.ts
+++ b/src/elements/card.ts
@@ -144,8 +144,8 @@ export class TodayCard extends LitElement {
                 @action=${this.handleTapAction}
                 .actionHandler=${actionHandler()}
             >
-                ${actionable ? html`<ha-ripple></ha-ripple>` : nothing}
                 <div class="card-content">${this.renderEvents()}</div>
+                ${actionable ? html`<ha-ripple></ha-ripple>` : nothing}
             </ha-card>
         `;
     }


### PR DESCRIPTION
As described in #40, cards without a title but with a tap_action suffered from a visual layout bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the placement of the ripple effect within cards for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->